### PR TITLE
Define a default docker network:

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
       - "--api.insecure=true"
       - "--providers.docker=true"
       - "--providers.docker.exposedbydefault=false"
+      - "--providers.docker.network=api"
       - "--entrypoints.web.address=:80"
       - "--entrypoints.websecure.address=:443"
       - "--certificatesresolvers.myhttpchallenge.acme.httpchallenge=true"
@@ -242,6 +243,7 @@ networks:
     driver: bridge
     internal: false
   api:
+    name: api
     driver: bridge
     internal: true
   keycloak-postgresql:


### PR DESCRIPTION
Occasionally a gateway timeout error happens when trying to access `https://console.<HOSTNAME>/`,  `https://<HOSTNAME>/atlas/` and `https://<HOSTNAME>/auth/`.

With this PR th network _api_ is set to be used as default for connections amongst all
containers. This option can be overridden on a per-container basis
with the `traefik.docker.network` label.