### PR TITLE
Fix loading of vocabularies:

### DIFF
--- a/bin/start
+++ b/bin/start
@@ -26,7 +26,7 @@ docker-compose up -d
 
 if ! psql_table_exists vocab concept; then
   echo "=== UNPACKING VOCABULARY ==="
-  unzip -u data/vocabulary/vocab.zip
+  unzip -u data/vocabulary/vocab.zip -d data/vocabulary 
   echo "=== LOADING VOCABULARY ==="
   bin/run-sql src/sql/load_vocabulary.sql
 else

--- a/bin/start
+++ b/bin/start
@@ -25,6 +25,8 @@ psql_wait_ready
 docker-compose up -d
 
 if ! psql_table_exists vocab concept; then
+  echo "=== UNPACKING VOCABULARY ==="
+  unzip -u data/vocabulary/vocab.zip
   echo "=== LOADING VOCABULARY ==="
   bin/run-sql src/sql/load_vocabulary.sql
 else

--- a/src/sql/load_vocabulary.sql
+++ b/src/sql/load_vocabulary.sql
@@ -130,25 +130,25 @@ TRUNCATE concept_class CASCADE;
 TRUNCATE domain CASCADE;
 
 -- Temporary fix to include CPT4 concepts.
-\COPY CONCEPT FROM PROGRAM 'unzip -p /data/vocabulary/vocab.zip CONCEPT_CPT4.csv | awk ''BEGIN { FS="\t"; OFS="\t" } ; NR==1 || $2 {print;next}; {print $1, "CPT4 - " $7, $3, $4, $5, $6, $7, $8, $9, $10}''' WITH DELIMITER E'\t' CSV HEADER QUOTE E'\b' ;
+\COPY CONCEPT FROM '/data/vocabulary/CONCEPT_CPT4.csv | awk ''BEGIN { FS="\t"; OFS="\t" } ; NR==1 || $2 {print;next}; {print $1, "CPT4 - " $7, $3, $4, $5, $6, $7, $8, $9, $10}''' WITH DELIMITER E'\t' CSV HEADER QUOTE E'\b' ;
 
-\COPY DRUG_STRENGTH FROM PROGRAM 'unzip -p /data/vocabulary/vocab.zip DRUG_STRENGTH.csv' WITH DELIMITER E'\t' CSV HEADER QUOTE E'\b' ;
+\COPY DRUG_STRENGTH FROM '/data/vocabulary/DRUG_STRENGTH.csv' WITH DELIMITER E'\t' CSV HEADER QUOTE E'\b' ;
 
-\COPY CONCEPT FROM PROGRAM 'unzip -p /data/vocabulary/vocab.zip CONCEPT.csv' WITH DELIMITER E'\t' CSV HEADER QUOTE E'\b' ;
+\COPY CONCEPT FROM '/data/vocabulary/CONCEPT.csv' WITH DELIMITER E'\t' CSV HEADER QUOTE E'\b' ;
 
-\COPY CONCEPT_RELATIONSHIP FROM PROGRAM 'unzip -p /data/vocabulary/vocab.zip CONCEPT_RELATIONSHIP.csv' WITH DELIMITER E'\t' CSV HEADER QUOTE E'\b' ;
+\COPY CONCEPT_RELATIONSHIP FROM '/data/vocabulary/CONCEPT_RELATIONSHIP.csv' WITH DELIMITER E'\t' CSV HEADER QUOTE E'\b' ;
 
-\COPY CONCEPT_ANCESTOR FROM PROGRAM 'unzip -p /data/vocabulary/vocab.zip CONCEPT_ANCESTOR.csv' WITH DELIMITER E'\t' CSV HEADER QUOTE E'\b' ;
+\COPY CONCEPT_ANCESTOR FROM '/data/vocabulary/CONCEPT_ANCESTOR.csv' WITH DELIMITER E'\t' CSV HEADER QUOTE E'\b' ;
 
-\COPY CONCEPT_SYNONYM FROM PROGRAM 'unzip -p /data/vocabulary/vocab.zip CONCEPT_SYNONYM.csv' WITH DELIMITER E'\t' CSV HEADER QUOTE E'\b' ;
+\COPY CONCEPT_SYNONYM FROM '/data/vocabulary/CONCEPT_SYNONYM.csv' WITH DELIMITER E'\t' CSV HEADER QUOTE E'\b' ;
 
-\COPY VOCABULARY FROM PROGRAM 'unzip -p /data/vocabulary/vocab.zip VOCABULARY.csv' WITH DELIMITER E'\t' CSV HEADER QUOTE E'\b' ;
+\COPY VOCABULARY FROM '/data/vocabulary/VOCABULARY.csv' WITH DELIMITER E'\t' CSV HEADER QUOTE E'\b' ;
 
-\COPY RELATIONSHIP FROM PROGRAM 'unzip -p /data/vocabulary/vocab.zip RELATIONSHIP.csv' WITH DELIMITER E'\t' CSV HEADER QUOTE E'\b' ;
+\COPY RELATIONSHIP FROM '/data/vocabulary/RELATIONSHIP.csv' WITH DELIMITER E'\t' CSV HEADER QUOTE E'\b' ;
 
-\COPY CONCEPT_CLASS FROM PROGRAM 'unzip -p /data/vocabulary/vocab.zip CONCEPT_CLASS.csv' WITH DELIMITER E'\t' CSV HEADER QUOTE E'\b' ;
+\COPY CONCEPT_CLASS FROM '/data/vocabulary/CONCEPT_CLASS.csv' WITH DELIMITER E'\t' CSV HEADER QUOTE E'\b' ;
 
-\COPY DOMAIN FROM PROGRAM 'unzip -p /data/vocabulary/vocab.zip DOMAIN.csv' WITH DELIMITER E'\t' CSV HEADER QUOTE E'\b' ;
+\COPY DOMAIN FROM '/data/vocabulary/DOMAIN.csv' WITH DELIMITER E'\t' CSV HEADER QUOTE E'\b' ;
 
 ALTER TABLE concept ADD CONSTRAINT xpk_concept PRIMARY KEY (concept_id);
 

--- a/src/sql/load_vocabulary.sql
+++ b/src/sql/load_vocabulary.sql
@@ -130,7 +130,7 @@ TRUNCATE concept_class CASCADE;
 TRUNCATE domain CASCADE;
 
 -- Temporary fix to include CPT4 concepts.
-\COPY CONCEPT FROM PROGRAM 'awk ''BEGIN { FS="\t"; OFS="\t" } ; NR==1 || $2 {print;next}; {print $1, "CPT4 - " $7, $3, $4, $5, $6, $7, $8, $9, $10}'' CONCEPT_CPT4.csv' WITH DELIMITER E'\t' CSV HEADER QUOTE E'\b' ;
+\COPY CONCEPT FROM PROGRAM 'awk ''BEGIN { FS="\t"; OFS="\t" } ; NR==1 || $2 {print;next}; {print $1, "CPT4 - " $7, $3, $4, $5, $6, $7, $8, $9, $10}'' /data/vocabulary/CONCEPT_CPT4.csv' WITH DELIMITER E'\t' CSV HEADER QUOTE E'\b' ;
 
 \COPY DRUG_STRENGTH FROM '/data/vocabulary/DRUG_STRENGTH.csv' WITH DELIMITER E'\t' CSV HEADER QUOTE E'\b' ;
 

--- a/src/sql/load_vocabulary.sql
+++ b/src/sql/load_vocabulary.sql
@@ -130,7 +130,7 @@ TRUNCATE concept_class CASCADE;
 TRUNCATE domain CASCADE;
 
 -- Temporary fix to include CPT4 concepts.
-\COPY CONCEPT FROM '/data/vocabulary/CONCEPT_CPT4.csv | awk ''BEGIN { FS="\t"; OFS="\t" } ; NR==1 || $2 {print;next}; {print $1, "CPT4 - " $7, $3, $4, $5, $6, $7, $8, $9, $10}''' WITH DELIMITER E'\t' CSV HEADER QUOTE E'\b' ;
+\COPY CONCEPT FROM PROGRAM 'awk ''BEGIN { FS="\t"; OFS="\t" } ; NR==1 || $2 {print;next}; {print $1, "CPT4 - " $7, $3, $4, $5, $6, $7, $8, $9, $10}'' CONCEPT_CPT4.csv' WITH DELIMITER E'\t' CSV HEADER QUOTE E'\b' ;
 
 \COPY DRUG_STRENGTH FROM '/data/vocabulary/DRUG_STRENGTH.csv' WITH DELIMITER E'\t' CSV HEADER QUOTE E'\b' ;
 


### PR DESCRIPTION
Inital loading of vocabularies is accompanied by this error message:
```
TRUNCATE domain CASCADE;
TRUNCATE TABLE
COPY  CONCEPT FROM STDIN WITH DELIMITER E'\t' CSV HEADER QUOTE E'\b' ;
sh: 1: unzip: not found
COPY 0
COPY  DRUG_STRENGTH FROM STDIN WITH DELIMITER E'\t' CSV HEADER QUOTE E'\b' ;
sh: 1: unzip: not found
```

Rather than including unzip in a custom container build based upon
bitnami/postgresql:13, we unzip the vocabularies just before creating the tables
inside the postgresql container.