### PR TITLE
Avoid infinite while loop:

### DIFF
--- a/lib/util.sh
+++ b/lib/util.sh
@@ -11,9 +11,17 @@ cat-env() {
 }
 
 psql_wait_ready() {
-  while ! docker-compose exec postgresql pg_isready -h localhost -U postgres -d ohdsi -q; do
-    sleep 10
+  counter=1
+  until docker-compose --log-level CRITICAL exec postgresql pg_isready -h localhost -U postgres -d ohdsi -q; do
+    sleep 1
     printf "."
+    if [ $counter -eq 10 ]
+    then
+        echo
+        docker-compose --log-level DEBUG exec postgresql pg_isready -h localhost -U postgres -d ohdsi
+        break
+    fi
+    counter=$(( $counter + 1 ))
   done
   echo
 }
@@ -21,15 +29,24 @@ psql_wait_ready() {
 psql_table_exists() {
   schema="$1"
   table="$2"
+  local level="${3:-CRITICAL}"
   source_exists_query="SELECT EXISTS (SELECT 1 FROM pg_tables WHERE schemaname = '${schema}' AND tablename = '${table}');"
-  docker-compose exec postgresql psql -h localhost -U postgres -c "${source_exists_query}" -tq ohdsi | grep -qe "^[[:space:]]*t[[:space:]]*$"
+  docker-compose --log-level "${level}" exec postgresql psql -h localhost -U postgres -c "${source_exists_query}" -tq ohdsi | grep -qe "^[[:space:]]*t[[:space:]]*$"
   return $?
 }
 
 psql_wait_table() {
-  while ! psql_table_exists "$1" "$2"; do
-    sleep 10
+  counter=1
+  until psql_table_exists "$1" "$2"; do
+    sleep 1
     printf "."
+    if [ $counter -eq 10 ]
+    then
+        echo
+        psql_table_exists "$1" "$2" "DEBUG"
+        break
+    fi
+    counter=$(( $counter + 1 ))
   done
   echo
 }


### PR DESCRIPTION
A fresh `bin/start` is accompanied by the following messages:
```
Creating volume "ohdsi-docker_jupyterhub_data" with local driver
Creating volume "ohdsi-docker_sftp_radboud_home" with local driver
Creating ohdsi-docker_postgresql_1 ... done
ERROR: 2
.
ohdsi-docker_postgresql_1 is up-to-date
Creating ohdsi-docker_jupyterhub-postgresql_1 ... done
Creating ohdsi-docker_sftp_1                  ... done
```
The `ERROR: 2` originates from `psql_wait_ready` from within `lib/util.sh`. There, a while loop checks the exit status of `pg_isready`. Unless there is no response, exit status 2 is provided and escalated to `docker-compose`. However, as there is no `--quiet` or `--silent` option for `docker-compose` the "error message" gets printed until the PostgreSQL server is accepting connections (exit code 0). In order to avoid this behaviour, I use the `--log-level` flag of `docker-compose` and set it to `CRITICAL` as long as we wait for the PostgeSQL server to be ready. If this is not the case within 10 secs, `--log-level` is set do `DEBUG` and the while loop is exited.